### PR TITLE
tracers/xray: Add source IP address to XRay trace

### DIFF
--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -172,9 +172,14 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span, const Http::HeaderMap
     span.setTag(Tracing::Tags::get().UserAgent, valueOrDefault(request_headers->UserAgent(), "-"));
     span.setTag(Tracing::Tags::get().HttpProtocol,
                 AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocol()));
-    const auto ip = stream_info.downstreamDirectRemoteAddress()->ip();
-    if (ip != nullptr) {
-      span.setTag(Tracing::Tags::get().PeerAddress, ip->addressAsString());
+
+    const auto& remoteAddress = stream_info.downstreamDirectRemoteAddress();
+    ASSERT(remoteAddress != nullptr);
+
+    if (remoteAddress->type() == Network::Address::Type::Ip) {
+      const auto remoteIP = remoteAddress->ip();
+      ASSERT(remoteIP != nullptr);
+      span.setTag(Tracing::Tags::get().PeerAddress, remoteIP->addressAsString());
     }
 
     if (request_headers->ClientTraceId()) {

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -172,6 +172,10 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span, const Http::HeaderMap
     span.setTag(Tracing::Tags::get().UserAgent, valueOrDefault(request_headers->UserAgent(), "-"));
     span.setTag(Tracing::Tags::get().HttpProtocol,
                 AccessLog::AccessLogFormatUtils::protocolToString(stream_info.protocol()));
+    const auto ip = stream_info.downstreamDirectRemoteAddress()->ip();
+    if (ip != nullptr) {
+      span.setTag(Tracing::Tags::get().PeerAddress, ip->addressAsString());
+    }
 
     if (request_headers->ClientTraceId()) {
       span.setTag(Tracing::Tags::get().GuidXClientTraceId,

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -175,12 +175,9 @@ void HttpTracerUtility::finalizeDownstreamSpan(Span& span, const Http::HeaderMap
 
     const auto& remoteAddress = stream_info.downstreamDirectRemoteAddress();
     ASSERT(remoteAddress != nullptr);
-
-    if (remoteAddress->type() == Network::Address::Type::Ip) {
-      const auto remoteIP = remoteAddress->ip();
-      ASSERT(remoteIP != nullptr);
-      span.setTag(Tracing::Tags::get().PeerAddress, remoteIP->addressAsString());
-    }
+    const auto remoteIP = remoteAddress->ip();
+    ASSERT(remoteIP != nullptr);
+    span.setTag(Tracing::Tags::get().PeerAddress, remoteIP->addressAsString());
 
     if (request_headers->ClientTraceId()) {
       span.setTag(Tracing::Tags::get().GuidXClientTraceId,

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -169,11 +169,15 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
   constexpr auto SpanStatus = "status";
   constexpr auto SpanUserAgent = "user_agent";
   constexpr auto SpanUrl = "url";
+  constexpr auto SpanClientIp = "client_ip";
+  constexpr auto SpanXForwardedFor = "x_forwarded_for";
+
   constexpr auto HttpUrl = "http.url";
   constexpr auto HttpMethod = "http.method";
   constexpr auto HttpStatusCode = "http.status_code";
   constexpr auto HttpUserAgent = "user_agent";
   constexpr auto HttpResponseSize = "response_size";
+  constexpr auto PeerAddress = "peer.address";
 
   if (name.empty() || value.empty()) {
     return;
@@ -189,6 +193,11 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
     http_response_annotations_.emplace(SpanStatus, value);
   } else if (name == HttpResponseSize) {
     http_response_annotations_.emplace(SpanContentLength, value);
+  } else if (name == PeerAddress) {
+    http_request_annotations_.emplace(SpanClientIp, value);
+    // In this case, PeerAddress refers to the client's actual IP address, not
+    // the address specified in the the HTTP X-Forwarded-For header.
+    http_request_annotations_.emplace(SpanXForwardedFor, "false");
   } else {
     custom_annotations_.emplace(name, value);
   }


### PR DESCRIPTION
Signed-off-by: Neal Patel <nealp9084@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: This PR adds additional fields to the XRay trace for the client IP address:
* `http.request.client_ip`
* `http.request.x_forwarded_for`

For details, see: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-http

Note that the upstream IP address is already present in the trace (it is currently a custom attribute).

Risk Level: Low
Testing: Updated unit tests, built on mac os, and built on ubuntu 18.04
Docs Changes: n/a
Release Notes: n/a
